### PR TITLE
Grabbing KeyBinds instead of defaultBinds

### DIFF
--- a/src/java/scheme/moded/ModedBinding.java
+++ b/src/java/scheme/moded/ModedBinding.java
@@ -48,7 +48,7 @@ public enum ModedBinding implements KeyBind {
     }
 
     public static void load() {
-        KeyBind[] orign = (KeyBind[]) Binding.values();
+        KeyBind[] orign = (KeyBind[]) keybinds.getKeybinds();
         KeyBind[] moded = (KeyBind[]) values();
         KeyBind[] binds = new KeyBind[orign.length + moded.length];
 


### PR DESCRIPTION
**Bugfix with other mods :**
While having this mod active, it would actively overwrite any keybinds that other mods put in. `Keybinds.getKeybinds()` gets all assigned keybinds instead of just mindustry's default `Binds.values()`

_Thats all, have a nice day._